### PR TITLE
custom name for templates variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = function(dest, options) {
                 path.basename(file.relative, path.extname(file.relative))
             );
         },
+        templatesVariableName: 'templates',
         hoganModule: 'hogan'
     }, options || {});
 
@@ -57,21 +58,23 @@ module.exports = function(dest, options) {
     }
 
     function endStream(){
+	   var templatesVariableName = options.templatesVariableName;
+
         // If no templates or dest is an object nothing more to do
         if (templates.length === 0 || typeof dest === 'object') {
             return this.emit('end');
         }
         var lines = [];
         for (var name in templates) {
-            lines.push('    templates[\'' + name + '\'] = new Hogan.Template(' + templates[name] + ');');
+            lines.push('    ' + templatesVariableName + '[\'' + name + '\'] = new Hogan.Template(' + templates[name] + ');');
         }
         // Unwrapped
-        lines.unshift('    var templates = {};');
+        lines.unshift('    var ' + templatesVariableName + ' = {};');
 
         // All wrappers require a hogan module
         if (options.wrapper) {
             lines.unshift('    var Hogan = require(\'' + options.hoganModule  + '\');');
-            lines.push('    return templates;');
+            lines.push('    return ' + templatesVariableName + ';');
         }
         // AMD wrapper
         if (options.wrapper === 'amd') {

--- a/test/main.js
+++ b/test/main.js
@@ -140,5 +140,25 @@ describe('gulp-compile-hogan', function() {
             stream.write(getFakeFile('test/views/special/file2.js', '{{greeting}} world'));
             stream.end();
         });
+
+    	it('should have custom template variable name', function(done) {
+    	    var stream = compile('test.js', {
+                templatesVariableName: "customTemplates"
+            });
+            stream.on('data', function(newFile){
+                var lines = newFile.contents.toString().split(gutil.linefeed);
+                lines[0].should.equal('define(function(require) {');
+                lines[1].should.equal('    var Hogan = require(\'hogan\');');
+                lines[2].should.equal('    var customTemplates = {};');
+                lines[3].should.match(/customTemplates\['foo\/file1'\] = new Hogan.Template/);
+                lines[4].should.match(/customTemplates\['file2'\] = new Hogan.Template/);
+                lines.pop().should.equal('})');
+                lines.pop().should.equal('    return customTemplates;');
+                done();
+            });
+            stream.write(getFakeFile('test/foo/file1.js', 'hello {{place}}'));
+            stream.write(getFakeFile('test/file2.js', '{{greeting}} world'));
+            stream.end();
+    	});
     });
 });


### PR DESCRIPTION
User should be able to configure variable name `templates`.  Added option `templatesVariableName` to define the name of variable. Default is `templates` if not specified.