### PR TITLE
added option for choosing namespace variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ A function that will be passed the file and should return a name for the templat
 
 The name of the hogan module *in your app*, defaults to `hogan`. If you're not using a wrapper then the global `Hogan` must be available.
 
+### namespace `string`
+
+The global variable name for when `wrapper` is `false`. The default value is `'templates'` which means the templates will be available on the `window.templates` object. 
+
 [gulp]:http://gulpjs.com
 [mustache]:http://mustache.github.io
 [hogan]:https://github.com/twitter/hogan.js

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ module.exports = function(dest, options) {
                 path.basename(file.relative, path.extname(file.relative))
             );
         },
-        hoganModule: 'hogan'
+        hoganModule: 'hogan',
+        namespace: 'templates'
     }, options || {});
 
     // Do not convert to strings if dest is an object
@@ -63,15 +64,15 @@ module.exports = function(dest, options) {
         }
         var lines = [];
         for (var name in templates) {
-            lines.push('    templates[\'' + name + '\'] = new Hogan.Template(' + templates[name] + ');');
+            lines.push('    ' + options.namespace + '[\'' + name + '\'] = new Hogan.Template(' + templates[name] + ');');
         }
         // Unwrapped
-        lines.unshift('    var templates = {};');
+        lines.unshift('    var ' + options.namespace + ' = {};');
 
         // All wrappers require a hogan module
         if (options.wrapper) {
             lines.unshift('    var Hogan = require(\'' + options.hoganModule  + '\');');
-            lines.push('    return templates;');
+            lines.push('    return ' + options.namespace + ';');
         }
         // AMD wrapper
         if (options.wrapper === 'amd') {

--- a/test/main.js
+++ b/test/main.js
@@ -140,5 +140,20 @@ describe('gulp-compile-hogan', function() {
             stream.write(getFakeFile('test/views/special/file2.js', '{{greeting}} world'));
             stream.end();
         });
+
+        it('should use the namespace variable name', function(done) {
+            var stream = compile('test.js', {
+                wrapper: false,
+                namespace: 'JST'
+            });
+            stream.on('data', function(newFile){
+                var lines = newFile.contents.toString().split(gutil.linefeed);
+                lines[0].should.equal('    var JST = {};');
+                lines[1].should.match(/JST\['file1'\] = new Hogan.Template/)
+                done();
+            });
+            stream.write(getFakeFile('test/file1.js', 'hello {{place}}'));
+            stream.end();
+        });
     });
 });


### PR DESCRIPTION
It's not a big deal, but I wanted templates on the standard `window.JST` object. This adds a new option, `namespace` for doing that.

```javascript
compile('jst.js', { wrapper: false, namespace: 'JST' })
```
