### PR TITLE
Add option to not include the Hogan runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ A function that will be passed the file and should return a name for the templat
 
 The name of the hogan module *in your app*, defaults to `hogan`. If you're not using a wrapper then the global `Hogan` must be available.
 
+### includeRuntime `boolean`
+
+If false, the Hogan runtime will not be included in the compiled template file. Use this if you'd like to include the runtime once globally.
+
 [gulp]:http://gulpjs.com
 [mustache]:http://mustache.github.io
 [hogan]:https://github.com/twitter/hogan.js

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ module.exports = function(dest, options) {
                 path.basename(file.relative, path.extname(file.relative))
             );
         },
-        hoganModule: 'hogan'
+        hoganModule: 'hogan',
+        includeRuntime: true
     }, options || {});
 
     // Do not convert to strings if dest is an object
@@ -70,7 +71,9 @@ module.exports = function(dest, options) {
 
         // All wrappers require a hogan module
         if (options.wrapper) {
-            lines.unshift('    var Hogan = require(\'' + options.hoganModule  + '\');');
+            if (options.includeRuntime) {
+              lines.unshift('    var Hogan = require(\'' + options.hoganModule  + '\');');
+            }
             lines.push('    return templates;');
         }
         // AMD wrapper

--- a/test/main.js
+++ b/test/main.js
@@ -95,6 +95,26 @@ describe('gulp-compile-hogan', function() {
             stream.end();
         });
 
+        it('should not require("hogan") if options.includeRuntime is false', function(done) {
+            var stream = compile('test.js', {
+                wrapper: 'commonjs',
+                includeRuntime: false
+            });
+            stream.on('data', function(newFile){
+                var lines = newFile.contents.toString().split(gutil.linefeed);
+                lines[0].should.equal('module.exports = (function() {');
+                lines[1].should.equal('    var templates = {};');
+                lines[2].should.match(/templates\['file1'\] = new Hogan.Template/);
+                lines[3].should.match(/templates\['file2'\] = new Hogan.Template/);
+                lines.pop().should.equal('})();');
+                lines.pop().should.equal('    return templates;');
+                done();
+            });
+            stream.write(getFakeFile('test/file1.js', 'hello {{place}}'));
+            stream.write(getFakeFile('test/file2.js', '{{greeting}} world'));
+            stream.end();
+        });
+
         it('should allow passing an object to populate with templates instead of a filename', function(done) {
             var templates = {};
             var stream = compile(templates);


### PR DESCRIPTION
It would be nice to have the option to not include the Hogan runtime in the compiled template file. That way including the file multiple times won't include the runtime more than once.